### PR TITLE
Fix: Typo in 1.configuration.md

### DIFF
--- a/content/2.api/1.configuration.md
+++ b/content/2.api/1.configuration.md
@@ -32,7 +32,7 @@ You can provide the `host` and `id` as env variables.
 Simply add `NUXT_UMAMI_HOST` and `NUXT_UMAMI_ID` to your .env file.
 
 ::alert{type="info" icon="ph:info-bold"}
-  Provided env variables will override the base config in `nuxt.confi.ts`.
+  Provided env variables will override the base config in `nuxt.config.ts`.
 ::
 
 ::alert{type="info" icon="ph:lightbulb-bold"}


### PR DESCRIPTION
## Summary
Corrects a typo `nuxt.confi.ts` -> `nuxt.config.ts`